### PR TITLE
Null reference exception fixed

### DIFF
--- a/Libraries/dotNetRDF/Update/Protocol/ProtocolToUpdateProcessor.cs
+++ b/Libraries/dotNetRDF/Update/Protocol/ProtocolToUpdateProcessor.cs
@@ -268,7 +268,10 @@ namespace VDS.RDF.Update.Protocol
             }
 
             SparqlParameterizedString put = new SparqlParameterizedString(cmdSequence.ToString());
-            put.Namespaces = g.NamespaceMap;
+            if(g != null)
+            {
+                put.Namespaces = g.NamespaceMap;
+            }
             if (graphUri != null) put.SetUri("graph", graphUri);
             SparqlUpdateCommandSet putCmds = _parser.ParseFromString(put);
             _updateProcessor.ProcessCommandSet(putCmds);


### PR DESCRIPTION
There was an option to get NullReferenceException when 'g' equals null. So before call methon on 'g' it checks whether 'g' is not null.