### PR TITLE
Shared resource lock object fixed

### DIFF
--- a/Libraries/dotNetRDF/Query/Expressions/Functions/Arq/NowFunction.cs
+++ b/Libraries/dotNetRDF/Query/Expressions/Functions/Arq/NowFunction.cs
@@ -40,6 +40,8 @@ namespace VDS.RDF.Query.Expressions.Functions.Arq
         private SparqlQuery _currQuery;
         private IValuedNode _node;
 
+        private readonly object lockObject = new object();
+
         /// <summary>
         /// Gets the value of the function in the given Evaluation Context for the given Binding ID.
         /// </summary>
@@ -56,7 +58,7 @@ namespace VDS.RDF.Query.Expressions.Functions.Arq
             }
             if (_node == null || !ReferenceEquals(_currQuery, context.Query))
             {
-                lock (this)
+                lock(lockObject)
                 {
                     if (_node == null || !ReferenceEquals(_currQuery, context.Query))
                     {


### PR DESCRIPTION
Locking with shared resources increase the chance of deadlocks. Now it is a dedicated object ("lockObject") for each shared resource.