### PR TITLE
fix always false part

### DIFF
--- a/Libraries/dotNetRDF.Query.Spin/Model/BaseImpl/ModuleImpl.cs
+++ b/Libraries/dotNetRDF.Query.Spin/Model/BaseImpl/ModuleImpl.cs
@@ -144,15 +144,8 @@ namespace VDS.RDF.Query.Spin.Model
 
         public ICommand getBody()
         {
-            IResource node = null; //ModulesUtil.getBody(this);
-            if (node is IResource)
-            {
-                return SPINFactory.asCommand(node);
-            }
-            else
-            {
-                return null;
-            }
+            IResource node = null;
+            return SPINFactory.asCommand(node);
         }
 
 


### PR DESCRIPTION
In "Libraries/dotNetRDF.Query.Spin/Model/BaseImpl/ModuleImpl.cs" function getBody() contains several not implemented and commented out source code. If-else statement if part never executed it may lead to dead code and it cannot be used in production.