### PR TITLE
performance improvement string assertion

### DIFF
--- a/Libraries/dotNetRDF.Data.Virtuoso/VirtuosoManager.cs
+++ b/Libraries/dotNetRDF.Data.Virtuoso/VirtuosoManager.cs
@@ -269,7 +269,7 @@ namespace VDS.RDF.Storage
         /// <param name="graphUri">URI of the Graph to Load.</param>
         public override void LoadGraph(IGraph g, String graphUri)
         {
-            if (graphUri == null || graphUri.Equals(String.Empty))
+            if(string.IsNullOrEmpty(graphUri))
             {
                 this.LoadGraph(g, (Uri) null);
             }
@@ -286,7 +286,7 @@ namespace VDS.RDF.Storage
         /// <param name="graphUri">URI of the Graph to Load.</param>
         public override void LoadGraph(IRdfHandler handler, String graphUri)
         {
-            if (graphUri == null || graphUri.Equals(String.Empty))
+            if(string.IsNullOrEmpty(graphUri))
             {
                 this.LoadGraph(handler, (Uri) null);
             }


### PR DESCRIPTION
Previously used to assert strings String.Empty and String.Equals. Fixed to string.IsNullOrEmpty() to improve performance. Review needed!